### PR TITLE
sdk dosent utf encodes the request body

### DIFF
--- a/src/main/java/com/weeblycloud/utils/CloudClient.java
+++ b/src/main/java/com/weeblycloud/utils/CloudClient.java
@@ -169,11 +169,7 @@ public class CloudClient {
         }
         
         if(dataInBody) {
-            try {
-                ((HttpEntityEnclosingRequestBase) request).setEntity(new StringEntity(content));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+                ((HttpEntityEnclosingRequestBase) request).setEntity(new StringEntity(content,"utf-8"));
         }
 
         request.addHeader("X-Public-Key", apiKey);


### PR DESCRIPTION
the content  in request body is not utf encoded . 
while the hash generation is.
so if we have any non english characters it will give invald hash error